### PR TITLE
Enhance Texture Handling: Improved Texture2D::Create Method & Refactored Loading Functions & Add DXT2/DXT3 Support

### DIFF
--- a/Editor/OpenGl/FrameBuffer.cpp
+++ b/Editor/OpenGl/FrameBuffer.cpp
@@ -16,9 +16,14 @@ namespace Nippon
 		glFramebufferParameteri(GL_FRAMEBUFFER, GL_FRAMEBUFFER_DEFAULT_WIDTH, Width);
 		glFramebufferParameteri(GL_FRAMEBUFFER, GL_FRAMEBUFFER_DEFAULT_HEIGHT, Height);
 
-		U32 colorAttachment0 = Texture2D::Create(Width, Height, 1, GL_CLAMP_TO_EDGE, GL_NEAREST, GL_RGBA, GL_RGBA32F, GL_FLOAT, nullptr);
-		U32 colorAttachment1 = Texture2D::Create(Width, Height, 1, GL_CLAMP_TO_EDGE, GL_NEAREST, GL_RED_INTEGER, GL_R32UI, GL_UNSIGNED_INT, nullptr);
-		U32 depthStencilAttachment = Texture2D::Create(Width, Height, 1, GL_CLAMP_TO_EDGE, GL_NEAREST, GL_DEPTH_STENCIL, GL_DEPTH24_STENCIL8, GL_UNSIGNED_INT_24_8, nullptr);
+		U32 colorAttachment0 = Texture2D::Create(Width, Height, 1, GL_CLAMP_TO_EDGE, GL_NEAREST,
+			GL_RGBA, GL_RGBA32F, GL_FLOAT, nullptr, 0, false);
+
+		U32 colorAttachment1 = Texture2D::Create(Width, Height, 1, GL_CLAMP_TO_EDGE, GL_NEAREST,
+			GL_RED_INTEGER, GL_R32UI, GL_UNSIGNED_INT, nullptr, 0, false);
+
+		U32 depthStencilAttachment = Texture2D::Create(Width, Height, 1, GL_CLAMP_TO_EDGE, GL_NEAREST,
+			GL_DEPTH_STENCIL, GL_DEPTH24_STENCIL8, GL_UNSIGNED_INT_24_8, nullptr, 0, false);
 
 		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, colorAttachment0, 0);
 		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT1, GL_TEXTURE_2D, colorAttachment1, 0);

--- a/Editor/OpenGl/Texture2D.cpp
+++ b/Editor/OpenGl/Texture2D.cpp
@@ -1,10 +1,11 @@
-#include <Glad/glad.h>
+﻿#include <Glad/glad.h>
 
 #include <OpenGl/Texture2D.h>
 
 namespace Nippon
 {
-	U32 Texture2D::Create(U32 Width, U32 Height, U32 Channels, U32 Wrap, U32 Filter, U32 Format, U32 FormatInternal, U32 Type, void const* Data, bool Compressed)
+	U32 Texture2D::Create(U32 Width, U32 Height, U32 Channels, U32 Wrap, U32 Filter, U32 Format,
+		U32 FormatInternal, U32 Type, void const* Data, size_t DataSize, bool Compressed)
 	{
 		U32 id = 0;
 
@@ -17,9 +18,11 @@ namespace Nippon
 
 		glTextureParameteri(id, GL_TEXTURE_MIN_FILTER, (I32)Filter);
 
+		auto ourDataSize = DataSize == 0 ? Width * Height * Channels : DataSize;
+
 		if (Compressed)
 		{
-			glCompressedTexImage2D(GL_TEXTURE_2D, 0, FormatInternal, Width, Height, 0, Width * Height * Channels, Data);
+			glCompressedTexImage2D(GL_TEXTURE_2D, 0, FormatInternal, Width, Height, 0, ourDataSize, Data);
 		}
 		else
 		{

--- a/Editor/OpenGl/Texture2D.h
+++ b/Editor/OpenGl/Texture2D.h
@@ -11,8 +11,9 @@ namespace Nippon
 	{
 	public:
 
-		static U32 Create(U32 Width, U32 Height, U32 Channels, U32 Wrap, U32 Filter, U32 Format, U32 FormatInternal, U32 Type, void const* Data, bool Compressed = false);
-
+		//static U32 Create(U32 Width, U32 Height, U32 Channels, U32 Wrap, U32 Filter, U32 Format, U32 FormatInternal, U32 Type, void const* Data, bool Compressed = false);
+		static U32 Create(U32 Width, U32 Height, U32 Channels, U32 Wrap, U32 Filter, U32 Format,
+			U32 FormatInternal, U32 Type, void const* Data, size_t DataSize, bool Compressed = false);
 		static void Destroy(U32 Texture);
 		static void Destroy(std::vector<U32> const& Textures);
 

--- a/Editor/Utility/TextureUtility.cpp
+++ b/Editor/Utility/TextureUtility.cpp
@@ -23,63 +23,60 @@
 
 namespace Nippon
 {
+	namespace
+	{
+		U32 CreateTextureFromImage(const DirectX::Image* mip, DXGI_FORMAT format)
+		{
+			switch (format)
+			{
+				case DXGI_FORMAT_BC1_UNORM:
+					return Texture2D::Create((U32)mip->width, (U32)mip->height, 1, GL_REPEAT, GL_LINEAR_MIPMAP_LINEAR, GL_RGBA, GL_COMPRESSED_SRGB_ALPHA_BPTC_UNORM_ARB, GL_UNSIGNED_BYTE, mip->pixels, true);
+				case DXGI_FORMAT_BC7_UNORM:
+					return Texture2D::Create((U32)mip->width, (U32)mip->height, 1, GL_REPEAT, GL_LINEAR_MIPMAP_LINEAR, GL_RGBA, GL_COMPRESSED_RGBA_BPTC_UNORM_ARB, GL_UNSIGNED_BYTE, mip->pixels, true);
+				default:
+					Log::Add("Unsupported texture format 0x%X found\n", format);
+					return 0;
+			}
+		}
+
+		U32 LoadDDS(const DirectX::ScratchImage& image)
+		{
+			const DirectX::Image* mip = image.GetImage(0, 0, 0);
+			
+			return CreateTextureFromImage(mip, image.GetMetadata().format);
+		}
+
+		U32 LoadPNG(U8 const* data, I32 width, I32 height)
+		{
+			return Texture2D::Create(width, height, 4, GL_CLAMP_TO_EDGE, GL_LINEAR_MIPMAP_LINEAR, GL_RGBA, GL_RGBA, GL_UNSIGNED_BYTE, data);
+		}
+	}
+
 	U32 TextureUtility::ReadDDS(fs::path const& File)
 	{
-		U32 texture = 0;
-
 		DirectX::ScratchImage image = {};
 
 		DirectX::LoadFromDDSFile(File.wstring().data(), DirectX::DDS_FLAGS_NONE, nullptr, image);
 
-		DirectX::Image const* mip = image.GetImage(0, 0, 0);
-
-		switch (image.GetMetadata().format)
-		{
-			case DXGI_FORMAT_BC1_UNORM: texture = Texture2D::Create((U32)mip->width, (U32)mip->height, 1, GL_REPEAT, GL_LINEAR_MIPMAP_LINEAR, GL_RGBA, GL_COMPRESSED_SRGB_ALPHA_BPTC_UNORM_ARB, GL_UNSIGNED_BYTE, mip->pixels, true); break;
-			case DXGI_FORMAT_BC7_UNORM: texture = Texture2D::Create((U32)mip->width, (U32)mip->height, 1, GL_REPEAT, GL_LINEAR_MIPMAP_LINEAR, GL_RGBA, GL_COMPRESSED_RGBA_BPTC_UNORM_ARB, GL_UNSIGNED_BYTE, mip->pixels, true); break;
-			default:
-			{
-				Log::Add("Unsupported texture format 0x%X found\n", image.GetMetadata().format);
-			}
-		}
-
-		return texture;
+		return LoadDDS(image);
 	}
 
 	U32 TextureUtility::ReadDDS(U8 const* Bytes, U64 Size)
 	{
-		U32 texture = 0;
-
 		DirectX::ScratchImage image = {};
 
 		DirectX::LoadFromDDSMemory(Bytes, Size, DirectX::DDS_FLAGS_NONE, nullptr, image);
 
-		DirectX::Image const* mip = image.GetImage(0, 0, 0);
-
-		switch (image.GetMetadata().format)
-		{
-			case DXGI_FORMAT_BC1_UNORM: texture = Texture2D::Create((U32)mip->width, (U32)mip->height, 1, GL_REPEAT, GL_LINEAR_MIPMAP_LINEAR, GL_RGB, GL_COMPRESSED_RGB_S3TC_DXT1_EXT, GL_UNSIGNED_BYTE, mip->pixels, true); break;
-			case DXGI_FORMAT_BC7_UNORM: texture = Texture2D::Create((U32)mip->width, (U32)mip->height, 1, GL_REPEAT, GL_LINEAR_MIPMAP_LINEAR, GL_RGBA, GL_COMPRESSED_RGBA_BPTC_UNORM_ARB, GL_UNSIGNED_BYTE, mip->pixels, true); break;
-			default:
-			{
-				Log::Add("Unsupported texture format 0x%X found\n", image.GetMetadata().format);
-			}
-		}
-
-		return texture;
+		return LoadDDS(image);
 	}
 
 	U32 TextureUtility::ReadPNG(fs::path const& File)
 	{
-		U32 texture = 0;
-
-		I32 width = 0;
-		I32 height = 0;
-		I32 channels = 0;
+		I32 width = 0, height = 0, channels = 0;
 
 		U8* data = stbi_load(File.string().data(), &width, &height, &channels, 0);
 
-		texture = Texture2D::Create(width, height, 4, GL_CLAMP_TO_EDGE, GL_LINEAR_MIPMAP_LINEAR, GL_RGBA, GL_RGBA, GL_UNSIGNED_BYTE, data);
+		U32 texture = LoadPNG(data, width, height);
 
 		stbi_image_free(data);
 
@@ -88,15 +85,11 @@ namespace Nippon
 
 	U32 TextureUtility::ReadPNG(U8 const* Bytes, U64 Size)
 	{
-		U32 texture = 0;
-
-		I32 width = 0;
-		I32 height = 0;
-		I32 channels = 0;
+		I32 width = 0, height = 0, channels = 0;
 
 		U8* data = stbi_load_from_memory(Bytes, (I32)Size, &width, &height, &channels, 0);
 
-		texture = Texture2D::Create(width, height, 4, GL_CLAMP_TO_EDGE, GL_LINEAR_MIPMAP_LINEAR, GL_RGBA, GL_RGBA, GL_UNSIGNED_BYTE, data);
+		U32 texture = LoadPNG(data, width, height);
 
 		stbi_image_free(data);
 


### PR DESCRIPTION
This pull request includes several changes to enhance the texture creation and handling in the OpenGL editor. The most significant changes involve updating the `Texture2D::Create` method to include a new `DataSize` parameter, refactoring the texture utility functions, and improving the handling of compressed textures.

Enhancements to texture creation and handling:

* [`Editor/OpenGl/Texture2D.cpp`](diffhunk://#diff-cd63697bc0c74c7dcb5a4a4891ef146ae765582a9e5aedcd7cad4da515dc9f4eL1-R8): Updated the `Texture2D::Create` method to include a new `DataSize` parameter, which defaults to the calculated size if not provided. [[1]](diffhunk://#diff-cd63697bc0c74c7dcb5a4a4891ef146ae765582a9e5aedcd7cad4da515dc9f4eL1-R8) [[2]](diffhunk://#diff-cd63697bc0c74c7dcb5a4a4891ef146ae765582a9e5aedcd7cad4da515dc9f4eR21-R25)
* [`Editor/OpenGl/FrameBuffer.cpp`](diffhunk://#diff-9e51391ee11c2056d89ca3c6ffdea3045369acdde92b62ce0ee148f07a50e6c4L19-R26): Modified the calls to `Texture2D::Create` to include the new `DataSize` parameter.
* [`Editor/OpenGl/Texture2D.h`](diffhunk://#diff-fb3b4f3e0d55e733fa34502e898f4a178ffbb2e14a3430f40ddb95ebcbe7ac3dL14-R16): Updated the `Texture2D::Create` method signature to include the new `DataSize` parameter.

Refactoring texture utility functions:

* [`Editor/Utility/TextureUtility.cpp`](diffhunk://#diff-c2e3a54726631461ee74bc21419784bffb3939ecde5dc0063a1ff6f90662a369L26-R138): Refactored the texture utility functions by introducing helper functions `CreateTextureFromImage`, `LoadDDS`, and `LoadPNG` to streamline the texture creation process and improve code readability. [[1]](diffhunk://#diff-c2e3a54726631461ee74bc21419784bffb3939ecde5dc0063a1ff6f90662a369L26-R138) [[2]](diffhunk://#diff-c2e3a54726631461ee74bc21419784bffb3939ecde5dc0063a1ff6f90662a369L91-R151)