### PR TITLE
Fixed padding issue with models

### DIFF
--- a/Common/Misc/BinaryMediator.h
+++ b/Common/Misc/BinaryMediator.h
@@ -25,7 +25,7 @@ namespace Nippon
 		inline void SeekAbs(U64 Value) { mPosition = Value; }
 
 		inline void AlignUp(U64 Alignment) { mPosition = ALIGN_UP_BY(mPosition, Alignment); }
-		inline void AlignDown(U64 Alignment) { mPosition = ALIGN_UP_BY(mPosition, Alignment); }
+		inline void AlignDown(U64 Alignment) { mPosition = ALIGN_DOWN_BY(mPosition, Alignment); }
 
 		inline void ModUp(U64 Modulus) { mPosition -= mPosition % Modulus; }
 		inline void ModDown(U64 Modulus) { mPosition += mPosition % Modulus; }

--- a/Common/Model/Model.cpp
+++ b/Common/Model/Model.cpp
@@ -871,8 +871,8 @@ namespace Nippon
 								break;
 							}
 						}
-
-						mediator.AlignUp(DEFAULT_ALIGNMENT);
+						
+						//mediator.AlignUp(DEFAULT_ALIGNMENT);
 					}
 
 					for (U32 i = 0; i < mScrHeader.MeshCount; i++)
@@ -1549,17 +1549,22 @@ namespace Nippon
 				Mediator->Read<TextureMap>(subMesh.TextureMaps, subMesh.Header.VertexCount);
 			}
 
+			if (subMesh.Header.ColorWeightOffset)
+			{
+				Mediator->SeekAbs(mdStart + subMesh.Header.ColorWeightOffset);
+				Mediator->Read<ColorWeight>(subMesh.ColorWeights, subMesh.Header.VertexCount);
+			}
+
 			if (subMesh.Header.TextureUvOffset)
 			{
 				Mediator->SeekAbs(mdStart + subMesh.Header.TextureUvOffset);
 				Mediator->Read<MdUv>(subMesh.TextureUvs, subMesh.Header.VertexCount);
 			}
 
-			if (subMesh.Header.ColorWeightOffset)
-			{
-				Mediator->SeekAbs(mdStart + subMesh.Header.ColorWeightOffset);
-				Mediator->Read<ColorWeight>(subMesh.ColorWeights, subMesh.Header.VertexCount);
-			}
+			U32 byteCount = (Mediator->GetPosition() - mdStart);
+			U32 paddingByteOffset = (0x80 - (byteCount % 0x80));
+
+			Mediator->SeekRel(paddingByteOffset);
 		}
 	}
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ git clone --branch main --depth 1 https://github.com/allogic/Nippon
 Setup.ps1
 ```
 Launch the Visual Studio Solution, set the `Editor` as the startup project and build for `Debug` or `Release` bitness `x64`.
+If you want to launch the editor through Visual Studio change the Debugging Working Directory in the Editor Project to $(TargetPath)
 
 #### Troubleshooting
  - If you got build errors, make sure you have the latest Visual Studio platform toolset v143 installed on your system.


### PR DESCRIPTION
Models had an issue where the padding of submeshes was not taken into account for the Mediator position. (Submeshes are aligned to 0x80 bytes)
Additionally the read order for the TextureUVs and the ColorWeights was incorrect. This also was fixed.

Lastly, the readme now includes a short instruction on how to launch the project through Visual Studio as by default the working directory is the project directory which prevents the Editor from loading the fonts.